### PR TITLE
Add previews in line with file data table

### DIFF
--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -71,7 +71,7 @@ javascript: (function () {
 
   // Add new column for image previews if one doesn't already exist
   var preExistingPreviewHeader = document.getElementsByClassName('image_preview');
-  if (!preExistingPreviewHeader) {
+  if (preExistingPreviewHeader.length === 0) {
     var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
     var additionalColumn = document.createElement('th');
     additionalColumn.innerText = "Image Preview";
@@ -84,7 +84,7 @@ javascript: (function () {
   formTableDataRows.forEach((row) => {
     // check if previewTd already exists
     var preExistingPreviewTd = document.getElementsByClassName('preview_td')
-    if (!preExistingPreviewTd) {
+    if (preExistingPreviewTd.length === 0) {
       var imageLinkTd = row.getElementsByTagName('td')[1];
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
       var imageLinkHref = imageLinkTdATag.href;

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -69,30 +69,37 @@ javascript: (function () {
       "https://mozilla.github.io/pdf.js/build/pdf.worker.js";
   };
 
-  // Add new column for image previews 
-  var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
-  var additionalColumn = document.createElement('th');
-  additionalColumn.innerText = "Image Preview";
-  additionalColumn.id = "image_preview";
-  formTableHeaderRows[0].appendChild(additionalColumn);
+  // Add new column for image previews if one doesn't already exist
+  var preExistingPreviewHeader = document.getElementsByClassName('image_preview');
+  if (!preExistingPreviewHeader) {
+    var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
+    var additionalColumn = document.createElement('th');
+    additionalColumn.innerText = "Image Preview";
+    additionalColumn.id = "image_preview";
+    formTableHeaderRows[0].appendChild(additionalColumn);
+  }
 
-  // loop through table to get insert previews
+  // loop through table to get insert preview images
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
   formTableDataRows.forEach((row) => {
-    var imageLinkTd = row.getElementsByTagName('td')[1];
-    var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
-    var imageLinkHref = imageLinkTdATag.href;
-    var previewTd = document.createElement('td');
-    previewTd.id = 'preview-td';
-    row.appendChild(previewTd);
-
-    var imageTag = document.createElement("img");
-    imageTag.style.width = "100%";
-    imageTag.src = imageLinkHref;
-    previewTd.appendChild(imageTag);
+    // check if previewTd already exists
+    var preExistingPreviewTd = document.getElementsByClassName('preview_td')
+    if (!preExistingPreviewTd) {
+      var imageLinkTd = row.getElementsByTagName('td')[1];
+      var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
+      var imageLinkHref = imageLinkTdATag.href;
+      var previewTd = document.createElement('td');
+      previewTd.id = 'preview-td';
+      previewTd.style.width = "30%";
+      row.appendChild(previewTd);
+  
+      var imageTag = document.createElement("img");
+      imageTag.style.width = "100%";
+      imageTag.src = imageLinkHref;
+      previewTd.appendChild(imageTag);
+    }
   });
   
-
   // Loop through all the links to Hub documents
   var existing_container = document.getElementById("linked_images");
   if (existing_container) {

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -85,7 +85,7 @@ javascript: (function () {
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
   formTableDataRows.forEach((row) => {
     // check if previewTd already exists
-    var preExistingPreviewTd = document.getElementsByClassName('preview_td')
+    var preExistingPreviewTd = document.getElementsByClassName('preview-td')
     console.log('looking for column')
     if (preExistingPreviewTd.length === 0) {
       console.log('creating column')

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -76,47 +76,20 @@ javascript: (function () {
   additionalColumn.id = "image_preview";
   formTableHeaderRows[0].appendChild(additionalColumn);
 
-  // loop through table to get preview image inserts 
+  // loop through table to get insert previews
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
   formTableDataRows.forEach((row) => {
-    var existing_preview_column = document.getElementsByClassName('preview-columns');
-    if (existing_preview_column) {
-      if (existing_preview_column.style.display !== "none") {
-        existing_preview_column.style.display = "none";
-      } else {
-        existing_preview_column.style.display = "block";
-      }
-    } else {
-      var imageLinkTd = row.getElementsByTagName('td')[1];
-      var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
-      var imageLinkHref = imageLinkTdATag.href;
-      var imageTitle = imageLinkTdATag.innerText;
+    var imageLinkTd = row.getElementsByTagName('td')[1];
+    var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
+    var imageLinkHref = imageLinkTdATag.href;
+    var previewTd = document.createElement('td');
+    previewTd.id = 'preview-td';
+    row.appendChild(previewTd);
 
-      if (
-        /\.pdf$/i.test(imageTitle) ||
-        /\.jpg$/i.test(imageTitle) ||
-        /\.jpeg$/i.test(imageTitle)
-      ) {
-        var previewTd = document.createElement('td');
-        previewTd.id = 'preview-td';
-        row.appendChild(previewTd);
-        previewTd.style.width = "30%";
-        var visible = null;
-        if (/\.pdf$/i.test(imageTitle)) {
-          visible = document.createElement("canvas");
-          previewTd.appendChild(visible);
-          setTimeout(() => loadPdf(imageLinkHref, visible), 1500);
-        } else {
-          visible = document.createElement("img");
-          visible.style.width = "100%";
-          visible.src = link.imageLinkHref;
-          imageLinkTd.appendChild(visible);
-          visible.onerror=function(){
-            previewTd.parentNode.removeChild(sub_container);
-          };
-        }
-      }
-    }
+    var imageTag = document.createElement("img");
+    imageTag.style.width = "100%";
+    imageTag.src = imageLinkHref;
+    previewTd.appendChild(imageTag);
   });
   
 

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -83,7 +83,7 @@ javascript: (function () {
     if (preExistingPreviewHeader[0].style.display !== "none") {
       preExistingPreviewHeader[0].style.display = "none";
     } else {
-      preExistingPreviewHeader[0].style.display = "block";
+      preExistingPreviewHeader[0].style.display = null;
     }
   }
 

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -77,7 +77,7 @@ javascript: (function () {
     var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
     var additionalColumn = document.createElement('th');
     additionalColumn.innerText = "Image Preview";
-    additionalColumn.id = "image_preview";
+    additionalColumn.className = "image_preview";
     formTableHeaderRows[0].appendChild(additionalColumn);
   }
 
@@ -93,7 +93,7 @@ javascript: (function () {
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
       var imageLinkHref = imageLinkTdATag.href;
       var previewTd = document.createElement('td');
-      previewTd.id = 'preview-td';
+      previewTd.className = 'preview-td';
       previewTd.style.width = "30%";
       row.appendChild(previewTd);
   

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -79,6 +79,12 @@ javascript: (function () {
     additionalColumn.innerText = "Image Preview";
     additionalColumn.className = "image_preview";
     formTableHeaderRows[0].appendChild(additionalColumn);
+  } else {
+    if (preExistingPreviewHeader[0].style.display !== "none") {
+      preExistingPreviewHeader[0].style.display = "none";
+    } else {
+      preExistingPreviewHeader[0].style.display = "block";
+    }
   }
 
   // loop through table to get insert preview images
@@ -102,6 +108,15 @@ javascript: (function () {
       imageTag.style.width = "100%";
       imageTag.src = imageLinkHref;
       previewTd.appendChild(imageTag);
+      imageTag.onerror = function() {
+        previewTd.parentNode.removeChild(previewTd)
+      }
+    } else {
+      if (preExistingPreviewTd.style.display !== "none") {
+        preExistingPreviewTd.style.display = "none";
+      } else {
+        preExistingPreviewTd.style.display = "block";
+      }
     }
   });
   

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -71,9 +71,7 @@ javascript: (function () {
 
   // Add new column for image previews if one doesn't already exist
   var preExistingPreviewHeader = document.getElementsByClassName('image_preview');
-  console.log('found exisitng header', preExistingPreviewHeader)
   if (preExistingPreviewHeader.length === 0) {
-    console.log('creatting header')
     var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
     var additionalColumn = document.createElement('th');
     additionalColumn.innerText = "Image Preview";
@@ -83,7 +81,7 @@ javascript: (function () {
     if (preExistingPreviewHeader[0].style.display !== "none") {
       preExistingPreviewHeader[0].style.display = "none";
     } else {
-      preExistingPreviewHeader[0].style.display = null;
+      preExistingPreviewHeader[0].style.display = "block";
     }
   }
 
@@ -93,9 +91,7 @@ javascript: (function () {
     // check if previewTd already exists
     var previewTdId = `preview_td_${index}`
     var preExistingPreviewTd = document.getElementById(previewTdId);
-    console.log('looking for column', preExistingPreviewTd);
     if (!preExistingPreviewTd) {
-      console.log('creating column')
       var imageLinkTd = row.getElementsByTagName('td')[1];
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
       var imageLinkHref = imageLinkTdATag.href;
@@ -115,7 +111,7 @@ javascript: (function () {
       if (preExistingPreviewTd.style.display !== "none") {
         preExistingPreviewTd.style.display = "none";
       } else {
-        preExistingPreviewTd.style.display = "block";
+        preExistingPreviewTd.style.display = null;
       }
     }
   });

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -85,15 +85,15 @@ javascript: (function () {
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
   formTableDataRows.forEach((row) => {
     // check if previewTd already exists
-    var preExistingPreviewTd = document.getElementsByClassName('preview-td')
-    console.log('looking for column')
+    var preExistingPreviewTd = document.getElementsByClassName('preview_td')
+    console.log('looking for column', preExistingPreviewTd)
     if (preExistingPreviewTd.length === 0) {
       console.log('creating column')
       var imageLinkTd = row.getElementsByTagName('td')[1];
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
       var imageLinkHref = imageLinkTdATag.href;
       var previewTd = document.createElement('td');
-      previewTd.className = 'preview-td';
+      previewTd.className = 'preview_td';
       previewTd.style.width = "30%";
       row.appendChild(previewTd);
   

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -83,17 +83,18 @@ javascript: (function () {
 
   // loop through table to get insert preview images
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
-  formTableDataRows.forEach((row) => {
+  formTableDataRows.forEach((row, index) => {
     // check if previewTd already exists
-    var preExistingPreviewTd = document.getElementsByClassName('preview_td')
-    console.log('looking for column', preExistingPreviewTd)
+    var previewTdId = `preview_td_${index}`
+    var preExistingPreviewTd = document.getElementsById(previewTdId);
+    console.log('looking for column', preExistingPreviewTd);
     if (preExistingPreviewTd.length === 0) {
       console.log('creating column')
       var imageLinkTd = row.getElementsByTagName('td')[1];
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
       var imageLinkHref = imageLinkTdATag.href;
       var previewTd = document.createElement('td');
-      previewTd.className = 'preview_td';
+      previewTd.id = previewTdId;
       previewTd.style.width = "30%";
       row.appendChild(previewTd);
   

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -83,6 +83,7 @@ javascript: (function () {
     var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
     var imageLinkHref = imageLinkTdATag.href;
     var previewTd = document.createElement('td');
+    previewTd.id = 'preview-td'
     row.appendChild(previewTd);
 
     var imageTag = document.createElement("img");

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -88,7 +88,7 @@ javascript: (function () {
     var previewTdId = `preview_td_${index}`
     var preExistingPreviewTd = document.getElementById(previewTdId);
     console.log('looking for column', preExistingPreviewTd);
-    if (preExistingPreviewTd.length === 0) {
+    if (!preExistingPreviewTd) {
       console.log('creating column')
       var imageLinkTd = row.getElementsByTagName('td')[1];
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -73,7 +73,17 @@ javascript: (function () {
   var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
   var additionalColumn = document.createElement('th');
   additionalColumn.innerText = "Image Preview";
-  formTableHeaderRows[0].appendChild(additionalColumn)
+  additionalColumn.id = "image_preview";
+  formTableHeaderRows[0].appendChild(additionalColumn);
+
+  // loop through table to get insert previews
+  var formTableDataRows = document.querySelectorAll("table > tbody > tr")
+  formTableDataRows.forEach((row) => {
+    var previewTd = document.createElement('td');
+    previewTd.innerText = 'Hello Preview';
+    row.appendChild(previewTd);
+  });
+  
 
   // Loop through all the links to Hub documents
   var existing_container = document.getElementById("linked_images");

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -71,7 +71,9 @@ javascript: (function () {
 
   // Add new column for image previews if one doesn't already exist
   var preExistingPreviewHeader = document.getElementsByClassName('image_preview');
+  console.log('found exisitng header', preExistingPreviewHeader)
   if (preExistingPreviewHeader.length === 0) {
+    console.log('creatting header')
     var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
     var additionalColumn = document.createElement('th');
     additionalColumn.innerText = "Image Preview";
@@ -84,7 +86,9 @@ javascript: (function () {
   formTableDataRows.forEach((row) => {
     // check if previewTd already exists
     var preExistingPreviewTd = document.getElementsByClassName('preview_td')
+    console.log('looking for column')
     if (preExistingPreviewTd.length === 0) {
+      console.log('creating column')
       var imageLinkTd = row.getElementsByTagName('td')[1];
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
       var imageLinkHref = imageLinkTdATag.href;

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -69,7 +69,7 @@ javascript: (function () {
       "https://mozilla.github.io/pdf.js/build/pdf.worker.js";
   };
 
-  // Add new column for image previews if one doesn't already exist
+  // Add new column header for image previews if one doesn't already exist
   var preExistingPreviewHeader = document.getElementsByClassName('image_preview');
   if (preExistingPreviewHeader.length === 0) {
     var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
@@ -85,21 +85,29 @@ javascript: (function () {
     }
   }
 
-  // loop through table to get insert preview images
+  // loop through table rows to create image previews (currently only available)
+  // for jpg and png
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
   formTableDataRows.forEach((row, index) => {
-    // check if previewTd already exists
+    // create unique ID per preview row -- preview_td_<row index>
     var previewTdId = `preview_td_${index}`
+    // check if previewTd already exists
     var preExistingPreviewTd = document.getElementById(previewTdId);
     if (!preExistingPreviewTd) {
+      // the 2nd column of the data files table is the file links
+      // grab the href file urls
       var imageLinkTd = row.getElementsByTagName('td')[1];
       var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
       var imageLinkHref = imageLinkTdATag.href;
+      // create an additional column per row to hold the preview images
       var previewTd = document.createElement('td');
+      // set column ID to prevew_td_<row index>
       previewTd.id = previewTdId;
       previewTd.style.width = "30%";
       row.appendChild(previewTd);
   
+      // create separate image tag to hold the previewable images
+      // TODO: figure out how to work with PDF files -- pdf files are the majority
       var imageTag = document.createElement("img");
       imageTag.style.width = "100%";
       imageTag.src = imageLinkHref;
@@ -126,14 +134,12 @@ javascript: (function () {
     }
   } else {
     var links = document.getElementsByTagName("a");
-    console.log('these are all the links', links)
     var container = document.createElement("div");
     container.id = "linked_images";
     container.className = "link_to_mage";
     container.width = "500px";
     for (var link_i = 0; link_i < links.length; link_i++) {
       var link = links[link_i];
-      console.log('this is the link i am working on now', link)
       var href = link.href;
       var link_txt = link.innerText;
       if (
@@ -146,24 +152,17 @@ javascript: (function () {
         sub_container.style.position = "relative";
         sub_container.style.width = "30%";
         sub_container.style.padding = "3px";
-        console.log('we have created a sub container', sub_container)
         var visible = null;
         if (/\.pdf$/i.test(link_txt)) {
           visible = document.createElement("canvas");
           sub_container.appendChild(visible);
-          console.log('we have the visible pdf canvas', visible)
           setTimeout(() => loadPdf(href, visible), 1500);
         } else {
           visible = document.createElement("img");
-          console.log('we have the visible image tag', visible)
           visible.style.width = "100%";
-          console.log('the image tag style is', visible.style.width)
           visible.src = link.href;
-          console.log('the image tag src is', visible.src)
           sub_container.appendChild(visible);
-          console.log('we appended the visible tag to sub container', sub_container)
           visible.onerror=function(msg, url, lineNo, columnNo, error){
-            console.log('there was an error', error)
             sub_container.parentNode.removeChild(sub_container);
           };
         }

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -126,12 +126,14 @@ javascript: (function () {
     }
   } else {
     var links = document.getElementsByTagName("a");
+    console.log('these are all the links', links)
     var container = document.createElement("div");
     container.id = "linked_images";
     container.className = "link_to_mage";
     container.width = "500px";
     for (var link_i = 0; link_i < links.length; link_i++) {
       var link = links[link_i];
+      console.log('this is the link i am working on now', link)
       var href = link.href;
       var link_txt = link.innerText;
       if (
@@ -144,17 +146,24 @@ javascript: (function () {
         sub_container.style.position = "relative";
         sub_container.style.width = "30%";
         sub_container.style.padding = "3px";
+        console.log('we have created a sub container', sub_container)
         var visible = null;
         if (/\.pdf$/i.test(link_txt)) {
           visible = document.createElement("canvas");
           sub_container.appendChild(visible);
+          console.log('we have the visible pdf canvas', visible)
           setTimeout(() => loadPdf(href, visible), 1500);
         } else {
           visible = document.createElement("img");
+          console.log('we have the visible image tag', visible)
           visible.style.width = "100%";
+          console.log('the image tag style is', visible.style.width)
           visible.src = link.href;
+          console.log('the image tag src is', visible.src)
           sub_container.appendChild(visible);
-          visible.onerror=function(){
+          console.log('we appended the visible tag to sub container', sub_container)
+          visible.onerror=function(msg, url, lineNo, columnNo, error){
+            console.log('there was an error', error)
             sub_container.parentNode.removeChild(sub_container);
           };
         }

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -79,8 +79,11 @@ javascript: (function () {
   // loop through table to get insert previews
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
   formTableDataRows.forEach((row) => {
+    var imageLinkTd = row.getElementsByTagName('td')[1];
+    var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
+    var imageLinkHref = imageLinkTdATag.href;
     var previewTd = document.createElement('td');
-    previewTd.innerText = 'Hello Preview';
+    previewTd.innerText = imageLinkHref;
     row.appendChild(previewTd);
   });
   

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -76,20 +76,47 @@ javascript: (function () {
   additionalColumn.id = "image_preview";
   formTableHeaderRows[0].appendChild(additionalColumn);
 
-  // loop through table to get insert previews
+  // loop through table to get preview image inserts 
   var formTableDataRows = document.querySelectorAll("table > tbody > tr")
   formTableDataRows.forEach((row) => {
-    var imageLinkTd = row.getElementsByTagName('td')[1];
-    var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
-    var imageLinkHref = imageLinkTdATag.href;
-    var previewTd = document.createElement('td');
-    previewTd.id = 'preview-td';
-    row.appendChild(previewTd);
+    var existing_preview_column = document.getElementsByClassName('preview-columns');
+    if (existing_preview_column) {
+      if (existing_preview_column.style.display !== "none") {
+        existing_preview_column.style.display = "none";
+      } else {
+        existing_preview_column.style.display = "block";
+      }
+    } else {
+      var imageLinkTd = row.getElementsByTagName('td')[1];
+      var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
+      var imageLinkHref = imageLinkTdATag.href;
+      var imageTitle = imageLinkTdATag.innerText;
 
-    var imageTag = document.createElement("img");
-    imageTag.style.width = "100%";
-    imageTag.src = imageLinkHref;
-    previewTd.appendChild(imageTag);
+      if (
+        /\.pdf$/i.test(imageTitle) ||
+        /\.jpg$/i.test(imageTitle) ||
+        /\.jpeg$/i.test(imageTitle)
+      ) {
+        var previewTd = document.createElement('td');
+        previewTd.id = 'preview-td';
+        row.appendChild(previewTd);
+        previewTd.style.width = "30%";
+        var visible = null;
+        if (/\.pdf$/i.test(imageTitle)) {
+          visible = document.createElement("canvas");
+          previewTd.appendChild(visible);
+          setTimeout(() => loadPdf(imageLinkHref, visible), 1500);
+        } else {
+          visible = document.createElement("img");
+          visible.style.width = "100%";
+          visible.src = link.imageLinkHref;
+          imageLinkTd.appendChild(visible);
+          visible.onerror=function(){
+            previewTd.parentNode.removeChild(sub_container);
+          };
+        }
+      }
+    }
   });
   
 

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -83,7 +83,7 @@ javascript: (function () {
     var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
     var imageLinkHref = imageLinkTdATag.href;
     var previewTd = document.createElement('td');
-    previewTd.id = 'preview-td'
+    previewTd.id = 'preview-td';
     row.appendChild(previewTd);
 
     var imageTag = document.createElement("img");

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -86,7 +86,7 @@ javascript: (function () {
   formTableDataRows.forEach((row, index) => {
     // check if previewTd already exists
     var previewTdId = `preview_td_${index}`
-    var preExistingPreviewTd = document.getElementsById(previewTdId);
+    var preExistingPreviewTd = document.getElementById(previewTdId);
     console.log('looking for column', preExistingPreviewTd);
     if (preExistingPreviewTd.length === 0) {
       console.log('creating column')

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -83,8 +83,12 @@ javascript: (function () {
     var imageLinkTdATag = imageLinkTd.getElementsByTagName('a')[0];
     var imageLinkHref = imageLinkTdATag.href;
     var previewTd = document.createElement('td');
-    previewTd.innerText = imageLinkHref;
     row.appendChild(previewTd);
+
+    var imageTag = document.createElement("img");
+    imageTag.style.width = "100%";
+    imageTag.src = imageLinkHref;
+    previewTd.appendChild(imageTag);
   });
   
 

--- a/hub-client-images.js
+++ b/hub-client-images.js
@@ -69,6 +69,12 @@ javascript: (function () {
       "https://mozilla.github.io/pdf.js/build/pdf.worker.js";
   };
 
+  // Add new column for image previews 
+  var formTableHeaderRows = document.querySelectorAll("table > thead > tr");
+  var additionalColumn = document.createElement('th');
+  additionalColumn.innerText = "Image Preview";
+  formTableHeaderRows[0].appendChild(additionalColumn)
+
   // Loop through all the links to Hub documents
   var existing_container = document.getElementById("linked_images");
   if (existing_container) {


### PR DESCRIPTION
Creates an additional preview column in the files table to show jpg / png images.

TODO: preview pdf files

To test out this bookmarklet, create an additional bookmarklet with the following javascript:
```
javascript: (function() {
    var js = document.createElement('script');
    js.setAttribute('src', 'https://tarayoo.github.io/get-your-refund-scratch-experimental/hub-client-images.js');
    document.body.appendChild(js);
})();
```