### PR TITLE
Close #15, comment out Take Action missing functionality

### DIFF
--- a/bookmarklet.md
+++ b/bookmarklet.md
@@ -56,6 +56,7 @@ javascript: (function() {
 
 [See the code behind it on Github](https://github.com/michaelaltmann/get-your-refund).
 
+<!--
 # Take Action Bookmarklet
 
 This bookmarklet modifies the Take Action page. It adds a little configuration at the top of the page, whic you only need to use once. More importantly, it adds a `Send + Next` button. This button does three things with a single click
@@ -80,6 +81,7 @@ Document Edit screen, clck the bookmark provide a preview of the image.
 You can also set up TamperMonkey to run this whenever you visit the document edit page.
 Install TamperMonkey in your browser and then visit
 https://raw.githubusercontent.com/michaelaltmann/get-your-refund/gh-pages/hub-take-action.user.js
+-->
 
 # Image Edit Preview Bookmarklet
 

--- a/bookmarklet.md
+++ b/bookmarklet.md
@@ -56,14 +56,14 @@ javascript: (function() {
 
 [See the code behind it on Github](https://github.com/michaelaltmann/get-your-refund).
 
-<!--
+
 # Take Action Bookmarklet
 
-This bookmarklet modifies the Take Action page. It adds a little configuration at the top of the page, whic you only need to use once. More importantly, it adds a `Send + Next` button. This button does three things with a single click
+This bookmarklet modifies the Take Action page. It adds a little configuration at the top of the page, whic you only need to use once. More importantly, it adds a `Send + Next` button. This button does two things with a single click
 
 - sends the message you have created
-- resets the client's status to 'Not Ready', which is the current protocol
 - takes you to whatever view of clients you have defined in the configuration text box at the top of the screen. For example, perhaps you like to pick up your clients from
+<!-- - resets the client's status to 'Not Ready', which is the current protocol -->
 
 ```
 https://www.getyourrefund.org/en/hub/clients?order=asc&column=updated_at&status=intake_in_progress&year=2020&unassigned=true&needs_response=true&vita_partner_id=&page=1
@@ -81,7 +81,6 @@ Document Edit screen, clck the bookmark provide a preview of the image.
 You can also set up TamperMonkey to run this whenever you visit the document edit page.
 Install TamperMonkey in your browser and then visit
 https://raw.githubusercontent.com/michaelaltmann/get-your-refund/gh-pages/hub-take-action.user.js
--->
 
 # Image Edit Preview Bookmarklet
 

--- a/bookmarklet.md
+++ b/bookmarklet.md
@@ -59,7 +59,7 @@ javascript: (function() {
 
 # Take Action Bookmarklet
 
-This bookmarklet modifies the Take Action page. It adds a little configuration at the top of the page, whic you only need to use once. More importantly, it adds a `Send + Next` button. This button does two things with a single click
+This bookmarklet modifies the Take Action page. It adds a little configuration at the top of the page, which you only need to use once. More importantly, it adds a `Send + Next` button. This button does two things with a single click
 
 - sends the message you have created
 - takes you to whatever view of clients you have defined in the configuration text box at the top of the screen. For example, perhaps you like to pick up your clients from


### PR DESCRIPTION
If folks are busy, I might just merge it in as it's easy to reverse.

Close #15 as people are finding the Take Action bookmarklet a bit confusing [as CfA changes have made one part of it not work.] ~and CfA changes have made it obsolete. Let me know if I'm mistaken about that.~